### PR TITLE
Fix new rubocops warnings

### DIFF
--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -133,7 +133,7 @@ module K8s
       keep_annotation = @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"]
       return false unless keep_annotation
 
-      keep_annotation == resource.metadata&.annotations.dig(@checksum_annotation)
+      keep_annotation == resource.metadata&.annotations&.dig(@checksum_annotation)
     end
 
     # Delete all stack resources that were not applied


### PR DESCRIPTION
There are new cops in recent rubocop's versions, and as they're enabled by default, new warnings emerge. This PRs fix those small warnings