### PR TITLE
Fix Ruby 2.7 warnings (required updating to the latest dry-types version)

### DIFF
--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -1,5 +1,4 @@
-
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "k8s/ruby/version"
 
@@ -15,7 +14,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "bin"
@@ -24,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_runtime_dependency "excon", "~> 0.71"
-  spec.add_runtime_dependency "dry-struct", "~> 0.5.0"
-  spec.add_runtime_dependency "dry-types", "~> 0.13.0"
-  spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.0"
+  spec.add_runtime_dependency "dry-struct", "~> 1.3.0"
+  spec.add_runtime_dependency "dry-types", "~> 1.4.0"
+  spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.3"
   spec.add_runtime_dependency 'hashdiff', '~> 1.0.0'
   spec.add_runtime_dependency 'jsonpath', '~> 0.9.5'
   spec.add_runtime_dependency 'yajl-ruby', '~> 1.4.0'

--- a/lib/k8s/api.rb
+++ b/lib/k8s/api.rb
@@ -8,7 +8,7 @@ module K8s
   module API
     # Common Dry::Types used in the API
     module Types
-      include Dry::Types.module
+      include Dry::Types()
     end
 
     # Common API struct type, handling JSON transforms with symbol keys

--- a/lib/k8s/api/metav1/api_resource.rb
+++ b/lib/k8s/api/metav1/api_resource.rb
@@ -8,12 +8,12 @@ module K8s
         attribute :name, Types::Strict::String
         attribute :singularName, Types::Strict::String
         attribute :namespaced, Types::Strict::Bool
-        attribute :group, Types::Strict::String.optional.default(nil)
-        attribute :version, Types::Strict::String.optional.default(nil)
+        attribute :group, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :version, Types::Strict::String.optional.default(nil, shared: true)
         attribute :kind, Types::Strict::String
         attribute :verbs, Types::Strict::Array.of(Types::Strict::String)
-        attribute :shortNames, Types::Strict::Array.of(Types::Strict::String).optional.default(proc { [] })
-        attribute :categories, Types::Strict::Array.of(Types::Strict::String).optional.default(proc { [] })
+        attribute :shortNames, Types::Strict::Array.of(Types::Strict::String).optional.default(proc { [] }, shared: true)
+        attribute :categories, Types::Strict::Array.of(Types::Strict::String).optional.default(proc { [] }, shared: true)
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIResourceList

--- a/lib/k8s/api/metav1/object.rb
+++ b/lib/k8s/api/metav1/object.rb
@@ -9,8 +9,8 @@ module K8s
       class OwnerReference < Resource
         attribute :name, Types::Strict::String
         attribute :uid, Types::Strict::String
-        attribute :controller, Types::Strict::Bool.optional.default(nil)
-        attribute :blockOwnerDeletion, Types::Strict::Bool.optional.default(nil)
+        attribute :controller, Types::Strict::Bool.optional.default(nil, shared: true)
+        attribute :blockOwnerDeletion, Types::Strict::Bool.optional.default(nil, shared: true)
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Initializer
@@ -21,32 +21,32 @@ module K8s
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Initializers
       class Initializers < Struct
         attribute :pending, Initializer
-        attribute :result, Status.optional.default(nil)
+        attribute :result, Status.optional.default(nil, shared: true)
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta
       class ObjectMeta < Resource
-        attribute :name, Types::Strict::String.optional.default(nil)
-        attribute :generateName, Types::Strict::String.optional.default(nil)
-        attribute :namespace, Types::Strict::String.optional.default(nil)
-        attribute :selfLink, Types::Strict::String.optional.default(nil)
-        attribute :uid, Types::Strict::String.optional.default(nil)
-        attribute :resourceVersion, Types::Strict::String.optional.default(nil)
-        attribute :generation, Types::Strict::Integer.optional.default(nil)
-        attribute :creationTimestamp, Types::DateTime.optional.default(nil)
-        attribute :deletionTimestamp, Types::DateTime.optional.default(nil)
-        attribute :deletionGracePeriodSeconds, Types::Strict::Integer.optional.default(nil)
-        attribute :labels, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
-        attribute :annotations, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
-        attribute :ownerReferences, Types::Strict::Array.of(OwnerReference).optional.default([])
-        attribute :initializers, Initializers.optional.default(nil)
-        attribute :finalizers, Types::Strict::Array.of(Types::Strict::String).optional.default([])
-        attribute :clusterName, Types::Strict::String.optional.default(nil)
+        attribute :name, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :generateName, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :namespace, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :selfLink, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :uid, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :resourceVersion, Types::Strict::String.optional.default(nil, shared: true)
+        attribute :generation, Types::Strict::Integer.optional.default(nil, shared: true)
+        attribute :creationTimestamp, Types::DateTime.optional.default(nil, shared: true)
+        attribute :deletionTimestamp, Types::DateTime.optional.default(nil, shared: true)
+        attribute :deletionGracePeriodSeconds, Types::Strict::Integer.optional.default(nil, shared: true)
+        attribute :labels, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil, shared: true)
+        attribute :annotations, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil, shared: true)
+        attribute :ownerReferences, Types::Strict::Array.of(OwnerReference).optional.default([].freeze)
+        attribute :initializers, Initializers.optional.default(nil, shared: true)
+        attribute :finalizers, Types::Strict::Array.of(Types::Strict::String).optional.default([].freeze)
+        attribute :clusterName, Types::Strict::String.optional.default(nil, shared: true)
       end
 
       # common attributes shared by all object types
       class ObjectCommon < Resource
-        attribute :metadata, ObjectMeta.optional.default(nil)
+        attribute :metadata, ObjectMeta.optional.default(nil, shared: true)
       end
     end
   end

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -25,16 +25,20 @@ module K8s
   class Config < ConfigStruct
     # Common dry-types for config
     class Types
-      include Dry::Types.module
+      include Dry::Types()
     end
 
     # structured cluster
     class Cluster < ConfigStruct
       attribute :server, Types::String
-      attribute :insecure_skip_tls_verify, Types::Bool.optional.default(nil)
-      attribute :certificate_authority, Types::String.optional.default(nil)
-      attribute :certificate_authority_data, Types::String.optional.default(nil)
-      attribute :extensions, Types::Strict::Array.optional.default(nil)
+      attribute :insecure_skip_tls_verify,
+                Types::Bool.optional.default(nil, shared: true)
+      attribute :certificate_authority,
+                Types::String.optional.default(nil, shared: true)
+      attribute :certificate_authority_data,
+                Types::String.optional.default(nil, shared: true)
+      attribute :extensions,
+                Types::Strict::Array.optional.default(nil, shared: true)
     end
 
     # structured cluster with name
@@ -54,25 +58,25 @@ module K8s
       attribute :command, Types::String
       attribute :apiVersion, Types::String
       attribute :env, Types::Strict::Array.of(Types::Hash).optional.default(nil)
-      attribute :args, Types::Strict::Array.of(Types::String).optional.default(nil)
+      attribute :args, Types::Strict::Array.of(Types::String).optional.default(nil, shared: true)
     end
 
     # structured user
     class User < ConfigStruct
-      attribute :client_certificate, Types::String.optional.default(nil)
-      attribute :client_certificate_data, Types::String.optional.default(nil)
-      attribute :client_key, Types::String.optional.default(nil)
-      attribute :client_key_data, Types::String.optional.default(nil)
-      attribute :token, Types::String.optional.default(nil)
-      attribute :tokenFile, Types::String.optional.default(nil)
-      attribute :as, Types::String.optional.default(nil)
-      attribute :as_groups, Types::Array.of(Types::String).optional.default(nil)
-      attribute :as_user_extra, Types::Hash.optional.default(nil)
-      attribute :username, Types::String.optional.default(nil)
-      attribute :password, Types::String.optional.default(nil)
-      attribute :auth_provider, UserAuthProvider.optional.default(nil)
-      attribute :exec, UserExec.optional.default(nil)
-      attribute :extensions, Types::Strict::Array.optional.default(nil)
+      attribute :client_certificate, Types::String.optional.default(nil, shared: true)
+      attribute :client_certificate_data, Types::String.optional.default(nil, shared: true)
+      attribute :client_key, Types::String.optional.default(nil, shared: true)
+      attribute :client_key_data, Types::String.optional.default(nil, shared: true)
+      attribute :token, Types::String.optional.default(nil, shared: true)
+      attribute :tokenFile, Types::String.optional.default(nil, shared: true)
+      attribute :as, Types::String.optional.default(nil, shared: true)
+      attribute :as_groups, Types::Array.of(Types::String).optional.default(nil, shared: true)
+      attribute :as_user_extra, Types::Hash.optional.default(nil, shared: true)
+      attribute :username, Types::String.optional.default(nil, shared: true)
+      attribute :password, Types::String.optional.default(nil, shared: true)
+      attribute :auth_provider, UserAuthProvider.optional.default(nil, shared: true)
+      attribute :exec, UserExec.optional.default(nil, shared: true)
+      attribute :extensions, Types::Strict::Array.optional.default(nil, shared: true)
     end
 
     # structured user with name
@@ -87,8 +91,8 @@ module K8s
     class Context < ConfigStruct
       attribute :cluster, Types::Strict::String
       attribute :user, Types::Strict::String
-      attribute :namespace, Types::Strict::String.optional.default(nil)
-      attribute :extensions, Types::Strict::Array.optional.default(nil)
+      attribute :namespace, Types::Strict::String.optional.default(nil, shared: true)
+      attribute :extensions, Types::Strict::Array.optional.default(nil, shared: true)
     end
 
     # named context
@@ -97,14 +101,14 @@ module K8s
       attribute :context, Context
     end
 
-    attribute :kind, Types::Strict::String.optional.default(nil)
-    attribute :apiVersion, Types::Strict::String.optional.default(nil)
-    attribute :preferences, Types::Strict::Hash.optional.default(proc { {} })
-    attribute :clusters, Types::Strict::Array.of(NamedCluster).optional.default(proc { [] })
-    attribute :users, Types::Strict::Array.of(NamedUser).optional.default(proc { [] })
-    attribute :contexts, Types::Strict::Array.of(NamedContext).optional.default(proc { [] })
-    attribute :current_context, Types::Strict::String.optional.default(nil)
-    attribute :extensions, Types::Strict::Array.optional.default(proc { [] })
+    attribute :kind, Types::Strict::String.optional.default(nil, shared: true)
+    attribute :apiVersion, Types::Strict::String.optional.default(nil, shared: true)
+    attribute :preferences, Types::Strict::Hash.optional.default(proc { {} }, shared: true)
+    attribute :clusters, Types::Strict::Array.of(NamedCluster).optional.default(proc { [] }, shared: true)
+    attribute :users, Types::Strict::Array.of(NamedUser).optional.default(proc { [] }, shared: true)
+    attribute :contexts, Types::Strict::Array.of(NamedContext).optional.default(proc { [] }, shared: true)
+    attribute :current_context, Types::Strict::String.optional.default(nil, shared: true)
+    attribute :extensions, Types::Strict::Array.optional.default(proc { [] }, shared: true)
 
     # Loads a configuration from a YAML file
     #

--- a/lib/k8s/resource.rb
+++ b/lib/k8s/resource.rb
@@ -42,11 +42,9 @@ module K8s
     # @param hash [Hash]
     # @param recurse_over_arrays [Boolean]
     # @param options [Hash] see RecursiveOpenStruct#initialize
-    def initialize(hash, recurse_over_arrays: true, **options)
-      super(hash,
-        recurse_over_arrays: recurse_over_arrays,
-        **options
-      )
+    def initialize(hash, **options)
+      options_with_defaults = { recurse_over_arrays: true }.merge(options)
+      super(hash, **options_with_defaults)
     end
 
     # @param options [Hash] see Hash#to_json

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -360,11 +360,8 @@ module K8s
     # @param options [Hash] @see #request
     # @return [Array<response_class, Hash, NilClass>]
     def get(*path, **options)
-      request(
-        method: 'GET',
-        path: self.path(*path),
-        **options
-      )
+      options = options.merge({ method: 'GET', path: self.path(*path) })
+      request(**options)
     end
 
     # @param paths [Array<String>]

--- a/spec/k8s/api_client_spec.rb
+++ b/spec/k8s/api_client_spec.rb
@@ -39,17 +39,17 @@ RSpec.describe K8s::APIClient do
 
     before do
       stub_request(:get, 'localhost:8080/api/v1')
-      .to_return(
-        status: 200,
-        body: fixture('api/api-v1.json'),
-        headers: { 'Content-Type' => 'application/json' }
-      )
+        .to_return(
+          status: 200,
+          body: fixture('api/api-v1.json'),
+          headers: { 'Content-Type' => 'application/json' }
+        )
     end
 
     describe '#api_resources' do
       it "returns array of APIResource" do
         expect(subject.api_resources.first).to match K8s::API::MetaV1::APIResource
-        expect(subject.api_resources.map{|r| r.name}).to match(
+        expect(subject.api_resources.map{ |r| r.name}).to match(
           # curl http://localhost:8001/api/v1 | jq -r '.resources[].name'
           <<-EOM
             bindings
@@ -96,7 +96,7 @@ RSpec.describe K8s::APIClient do
 
     describe '#resource' do
       it "raises error for non-existing resource" do
-        expect{subject.resource('wtfs')}.to raise_error(K8s::Error::UndefinedResource, %r(Unknown resource wtfs for v1))
+        expect{subject.resource('wtfs')}.to raise_error(K8s::Error::UndefinedResource, /Unknown resource wtfs for v1/)
       end
 
       it "returns client for resource name" do
@@ -107,10 +107,8 @@ RSpec.describe K8s::APIClient do
     describe '#client_for_resource' do
       context "for an invalid resource apiVersion" do
         let(:resource) {
-          K8s::Resource.new(
-            apiVersion: 'test/v1',
-            kind: 'Test',
-          )
+          K8s::Resource.new({ apiVersion: 'test/v1',
+                              kind: 'Test' })
         }
 
         it "raises error" do
@@ -120,14 +118,12 @@ RSpec.describe K8s::APIClient do
 
       context "for an invalid resource kind" do
         let(:resource) {
-          K8s::Resource.new(
-            apiVersion: 'v1',
-            kind: 'Wtf',
-          )
+          K8s::Resource.new({ apiVersion: 'v1',
+                              kind: 'Wtf' })
         }
 
         it "raises error" do
-          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error::UndefinedResource,  %r(Unknown resource kind=Wtf for v1))
+          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error::UndefinedResource, /Unknown resource kind=Wtf for v1/)
         end
       end
     end

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -31,10 +31,8 @@ RSpec.describe K8s::Client do
 
     let(:default_kubeconfig_path) { File.join(Dir.home, '.kube', 'config') }
 
-
     subject { described_class }
     context 'from KUBE_CA/KUBE_SERVER/KUBE_TOKEN variables' do
-
       let(:server) { "localhost" }
       let(:env) { { 'KUBE_TOKEN' => token, 'KUBE_CA' => ca, 'KUBE_SERVER' => server } }
 
@@ -159,12 +157,12 @@ RSpec.describe K8s::Client do
     STUB_APIS = {
       '/version' => 'api/version.json',
       '/api/v1' => 'api/api-v1.json',
-      '/apis' => 'api/apis.json',
-    }
+      '/apis' => 'api/apis.json'
+    }.freeze
 
     # jq -r '.groups[].versions[].groupVersion' spec/fixtures/api/apis.json
-    API_GROUPS = (
-        <<-EOM
+    API_GROUPS =
+      <<-EOM
           apiregistration.k8s.io/v1
           apiregistration.k8s.io/v1beta1
           extensions/v1beta1
@@ -189,8 +187,8 @@ RSpec.describe K8s::Client do
           storage.k8s.io/v1beta1
           admissionregistration.k8s.io/v1beta1
           apiextensions.k8s.io/v1beta1
-        EOM
-    ).split
+      EOM
+      .split
 
     before do
       STUB_APIS.each do |path, fixture_path|
@@ -216,7 +214,7 @@ RSpec.describe K8s::Client do
     describe '#version' do
       it "returns version" do
         expect(subject.version.to_hash).to match hash_including(
-          gitVersion: 'v1.10.5',
+          gitVersion: 'v1.10.5'
         )
       end
     end
@@ -225,14 +223,14 @@ RSpec.describe K8s::Client do
       it "returns core API with resources" do
         expect(subject.api).to match K8s::APIClient
         expect(subject.api.api_version).to eq 'v1'
-        expect(subject.api.api_resources.map{|r| r.name }).to include 'nodes', 'pods', 'services'
+        expect(subject.api.api_resources.map{ |r| r.name }).to include 'nodes', 'pods', 'services'
       end
 
       it "caches api_resources" do
         expect(transport).to receive(:get).with('/api/v1', Hash).once.and_call_original
 
         3.times do
-          expect(subject.api.api_resources.map{|r| r.name }).to include 'nodes', 'pods', 'services'
+          expect(subject.api.api_resources.map{ |r| r.name }).to include 'nodes', 'pods', 'services'
         end
       end
     end
@@ -241,7 +239,7 @@ RSpec.describe K8s::Client do
       it "returns client for each api" do
         expect(subject.apis).to match Array
         expect(subject.apis.first).to match K8s::APIClient
-        expect(subject.apis.map{|a| a.api_version}).to eq(['v1'] + API_GROUPS)
+        expect(subject.apis.map{ |a| a.api_version}).to eq(['v1'] + API_GROUPS)
       end
 
       context "with partially cached api resources" do
@@ -255,7 +253,7 @@ RSpec.describe K8s::Client do
 
           apis = subject.apis(prefetch_resources: true)
 
-          expect(apis.map{|api| api.api_resources}.flatten.map{|r| r.name}).to include 'nodes', 'pods', 'deployments', 'jobs'
+          expect(apis.map{ |api| api.api_resources}.flatten.map{ |r| r.name}).to include 'nodes', 'pods', 'deployments', 'jobs'
         end
       end
 
@@ -278,20 +276,22 @@ RSpec.describe K8s::Client do
     describe '#create_resource' do
       context "for a service resource" do
         let(:resource) { resource_fixture('resources/service.yaml') }
-        let(:server_resource) { resource.merge(
-          metadata: { resourceVersion: '1'}
-        ) }
+        let(:server_resource) {
+          resource.merge(
+            { metadata: { resourceVersion: '1' } }
+          )
+        }
 
         before do
           stub_request(:post, 'localhost:8080/api/v1/namespaces/default/services')
             .with(
               headers: { 'Content-Type' => 'application/json' },
-              body: resource.to_hash,
+              body: resource.to_hash
             )
             .to_return(
               status: 201,
               headers: { 'Content-Type' => 'application/json' },
-              body: server_resource.to_json,
+              body: server_resource.to_json
             )
         end
 
@@ -309,16 +309,18 @@ RSpec.describe K8s::Client do
     describe '#get_resource' do
       context "for a service resource" do
         let(:resource) { resource_fixture('resources/service.yaml') }
-        let(:server_resource) { resource.merge(
-          metadata: { resourceVersion: '1'}
-        ) }
+        let(:server_resource) {
+          resource.merge(
+            metadata: { resourceVersion: '1' }
+          )
+        }
 
         before do
           stub_request(:get, 'localhost:8080/api/v1/namespaces/default/services/whoami')
             .to_return(
               status: 200,
               headers: { 'Content-Type' => 'application/json' },
-              body: server_resource.to_json,
+              body: server_resource.to_json
             )
         end
 
@@ -335,23 +337,27 @@ RSpec.describe K8s::Client do
 
     describe '#update_resource' do
       context "for a service resource" do
-        let(:resource) { resource_fixture('resources/service.yaml').merge(
-          metadata: { resourceVersion: '1'}
-        ) }
-        let(:server_resource) { resource_fixture('resources/service.yaml').merge(
-          metadata: { resourceVersion: '2'}
-        ) }
+        let(:resource) {
+          resource_fixture('resources/service.yaml').merge(
+            metadata: { resourceVersion: '1' }
+          )
+        }
+        let(:server_resource) {
+          resource_fixture('resources/service.yaml').merge(
+            metadata: { resourceVersion: '2' }
+          )
+        }
 
         before do
           stub_request(:put, 'localhost:8080/api/v1/namespaces/default/services/whoami')
             .with(
               headers: { 'Content-Type' => 'application/json' },
-              body: resource.to_hash,
+              body: resource.to_hash
             )
             .to_return(
               status: 200,
               headers: { 'Content-Type' => 'application/json' },
-              body: server_resource.to_json,
+              body: server_resource.to_json
             )
         end
 
@@ -369,16 +375,18 @@ RSpec.describe K8s::Client do
     describe '#delete_resource' do
       context "for a service resource" do
         let(:resource) { resource_fixture('resources/service.yaml') }
-        let(:server_resource) { resource.merge(
-          metadata: { resourceVersion: '3'}
-        ) }
+        let(:server_resource) {
+          resource.merge(
+            metadata: { resourceVersion: '3' }
+          )
+        }
 
         before do
           stub_request(:delete, 'localhost:8080/api/v1/namespaces/default/services/whoami')
             .to_return(
               status: 200,
               headers: { 'Content-Type' => 'application/json' },
-              body: server_resource.to_json,
+              body: server_resource.to_json
             )
         end
 
@@ -395,10 +403,12 @@ RSpec.describe K8s::Client do
 
     describe '#get_resources' do
       context "for standard resources" do
-        let(:resources) {[
-          K8s::Resource.from_file(fixture_path('resources/service-foo.yaml')),
-          K8s::Resource.from_file(fixture_path('resources/configmap-bar.yaml')),
-        ]}
+        let(:resources) {
+          [
+            K8s::Resource.from_file(fixture_path('resources/service-foo.yaml')),
+            K8s::Resource.from_file(fixture_path('resources/configmap-bar.yaml'))
+          ]
+        }
 
         context "which already exist" do
           before do
@@ -406,13 +416,13 @@ RSpec.describe K8s::Client do
               .to_return(
                 status: 200,
                 headers: { 'Content-Type' => 'application/json' },
-                body: fixture('api/services-foo.json'),
+                body: fixture('api/services-foo.json')
               )
             stub_request(:get, 'localhost:8080/api/v1/namespaces/default/configmaps/bar')
               .to_return(
                 status: 200,
                 headers: { 'Content-Type' => 'application/json' },
-                body: fixture('api/configmaps-bar.json'),
+                body: fixture('api/configmaps-bar.json')
               )
           end
 
@@ -420,12 +430,12 @@ RSpec.describe K8s::Client do
             expect(transport).to receive(:requests).once.with(
               hash_including(path: '/api/v1'),
               skip_missing: true,
-              response_class: anything,
+              response_class: anything
             ).and_call_original
             expect(transport).to receive(:requests).once.with(
               hash_including(path: '/api/v1/namespaces/default/services/foo'),
               hash_including(path: '/api/v1/namespaces/default/configmaps/bar'),
-              skip_missing: true,
+              skip_missing: true
             ).and_call_original
 
             r = subject.get_resources(resources)
@@ -433,11 +443,11 @@ RSpec.describe K8s::Client do
             expect(r).to match [K8s::Resource, K8s::Resource]
             expect(r[0].to_hash).to match hash_including(
               apiVersion: 'v1',
-              kind: 'Service',
+              kind: 'Service'
             )
             expect(r[1].to_hash).to match hash_including(
               apiVersion: 'v1',
-              kind: 'ConfigMap',
+              kind: 'ConfigMap'
             )
           end
         end
@@ -448,13 +458,13 @@ RSpec.describe K8s::Client do
               .to_return(
                 status: 200,
                 headers: { 'Content-Type' => 'application/json' },
-                body: fixture('api/services-foo.json'),
+                body: fixture('api/services-foo.json')
               )
             stub_request(:get, 'localhost:8080/api/v1/namespaces/default/configmaps/bar')
               .to_return(
                 status: 404,
                 headers: { 'Content-Type' => 'application/json' },
-                body: fixture('api/configmaps-bar-404.json'),
+                body: fixture('api/configmaps-bar-404.json')
               )
           end
 
@@ -464,7 +474,7 @@ RSpec.describe K8s::Client do
             expect(r).to match [K8s::Resource, nil]
             expect(r[0].to_hash).to match hash_including(
               apiVersion: 'v1',
-              kind: 'Service',
+              kind: 'Service'
             )
             expect(r[1]).to be nil
           end
@@ -472,10 +482,12 @@ RSpec.describe K8s::Client do
       end
 
       context "for custom resources" do
-        let(:resources) {[
-          K8s::Resource.from_file(fixture_path('resources/test/crd-test.yaml')),
-          K8s::Resource.from_file(fixture_path('resources/test/test.yaml')),
-        ]}
+        let(:resources) {
+          [
+            K8s::Resource.from_file(fixture_path('resources/test/crd-test.yaml')),
+            K8s::Resource.from_file(fixture_path('resources/test/test.yaml'))
+          ]
+        }
 
         context "which do not yet exist" do
           before do
@@ -483,17 +495,17 @@ RSpec.describe K8s::Client do
               .to_return(
                 status: 404,
                 headers: { 'Content-Type' => 'text/plain' },
-                body: '404 page not found',
+                body: '404 page not found'
               )
             stub_request(:get, 'localhost:8080/apis/pharos-test.k8s.io/v0')
               .to_return(
                 status: 404,
                 headers: { 'Content-Type' => 'text/plain' },
-                body: '404 page not found',
+                body: '404 page not found'
               )
             stub_request(:get, 'localhost:8080/apis/pharos-test.k8s.io/v0/namespaces/default/tests/test')
               .to_return(
-                status: 404,
+                status: 404
               )
           end
 
@@ -519,8 +531,8 @@ RSpec.describe K8s::Client do
                 apiVersion: 'v1',
                 kind: 'ServiceList',
                 metadata: {},
-                items: [service_resource],
-              }.to_json,
+                items: [service_resource]
+              }.to_json
             )
           stub_request(:get, 'localhost:8080/api/v1/configmaps')
             .to_return(
@@ -530,16 +542,16 @@ RSpec.describe K8s::Client do
                 apiVersion: 'v1',
                 kind: 'ConfgiMapList',
                 metadata: {},
-                items: [],
-              }.to_json,
+                items: []
+              }.to_json
             )
         end
 
         it "returns existing resources" do
           expect(subject.list_resources([
-            subject.api('v1').resource('services'),
-            subject.api('v1').resource('configmaps'),
-          ])).to eq [service_resource]
+                                          subject.api('v1').resource('services'),
+                                          subject.api('v1').resource('configmaps')
+                                        ])).to eq [service_resource]
         end
       end
 
@@ -553,8 +565,8 @@ RSpec.describe K8s::Client do
                 apiVersion: 'v1',
                 kind: 'ServiceList',
                 metadata: {},
-                items: [service_resource],
-              }.to_json,
+                items: [service_resource]
+              }.to_json
             )
           stub_request(:get, 'localhost:8080/api/v1/configmaps')
             .to_return(
@@ -567,21 +579,21 @@ RSpec.describe K8s::Client do
         it "raises Forbidden" do
           expect{
             subject.list_resources([
-              subject.api('v1').resource('services'),
-              subject.api('v1').resource('configmaps'),
-            ])
+                                     subject.api('v1').resource('services'),
+                                     subject.api('v1').resource('configmaps')
+                                   ])
           }.to raise_error(K8s::Error::Forbidden)
         end
 
         describe 'skip_forbidden: true' do
           it "returns existing resources" do
             expect(subject.list_resources(
-              [
-                subject.api('v1').resource('services'),
-                subject.api('v1').resource('configmaps'),
-              ],
-              skip_forbidden: true,
-            )).to eq [service_resource]
+                     [
+                       subject.api('v1').resource('services'),
+                       subject.api('v1').resource('configmaps')
+                     ],
+                     skip_forbidden: true
+                   )).to eq [service_resource]
           end
         end
       end
@@ -591,9 +603,9 @@ RSpec.describe K8s::Client do
           allow(transport).to receive(:gets).and_raise(K8s::Error::NotFound.new('GET', '/foo', 404, 'NotFound'))
           expect{
             subject.list_resources([
-              subject.api('v1').resource('services'),
-              subject.api('v1').resource('configmaps'),
-            ])
+                                     subject.api('v1').resource('services'),
+                                     subject.api('v1').resource('configmaps')
+                                   ])
           }.to raise_error(K8s::Error::NotFound)
         end
       end

--- a/spec/k8s/resource_client_spec.rb
+++ b/spec/k8s/resource_client_spec.rb
@@ -5,25 +5,27 @@ RSpec.describe K8s::ResourceClient do
 
   context "for the nodes API" do
     let(:api_client) { K8s::APIClient.new(transport, 'v1') }
-    let(:api_resource) { K8s::API::MetaV1::APIResource.new(
-      name: "nodes",
-      singularName: "",
-      namespaced: false,
-      kind: "Node",
-      verbs: [
-        "create",
-        "delete",
-        "deletecollection",
-        "get",
-        "list",
-        "patch",
-        "update",
-        "watch",
-      ],
-      shortNames: [
-        "no",
-      ]
-    ) }
+    let(:api_resource) {
+      K8s::API::MetaV1::APIResource.new(
+        name: "nodes",
+        singularName: "",
+        namespaced: false,
+        kind: "Node",
+        verbs: %w(
+          create
+          delete
+          deletecollection
+          get
+          list
+          patch
+          update
+          watch
+        ),
+        shortNames: [
+          "no"
+        ]
+      )
+    }
 
     subject { described_class.new(transport, api_client, api_resource) }
 
@@ -56,13 +58,15 @@ RSpec.describe K8s::ResourceClient do
           list = subject.list
 
           expect(list).to match [K8s::Resource]
-          expect(list.map{|item| {
-            kind: item.kind,
-            namespace: item.metadata.namespace,
-            name: item.metadata.name,
-          } }).to match [
-            { kind: "Node", namespace: nil, name: "ubuntu-xenial" }
-          ]
+          expect(list.map{ |item|
+                   {
+                     kind: item.kind,
+                     namespace: item.metadata.namespace,
+                     name: item.metadata.name
+                   }
+                 }).to match [
+                   { kind: "Node", namespace: nil, name: "ubuntu-xenial" }
+                 ]
         end
       end
     end
@@ -90,11 +94,11 @@ RSpec.describe K8s::ResourceClient do
     end
 
     context "PUT /api/v1/nodes/*" do
-      let(:resource) { K8s::Resource.new(
-        kind: 'Node',
-        metadata: { name: 'test', resourceVersion: "1" },
-        spec: { unschedulable: true },
-      ) }
+      let(:resource) {
+        K8s::Resource.new({ kind: 'Node',
+                            metadata: { name: 'test', resourceVersion: "1" },
+                            spec: { unschedulable: true } })
+      }
 
       before do
         stub_request(:put, 'localhost:8080/api/v1/nodes/test')
@@ -103,13 +107,13 @@ RSpec.describe K8s::ResourceClient do
             body: {
               'kind' => 'Node',
               'metadata' => { 'name' => 'test', 'resourceVersion' => "1" },
-              'spec' => { 'unschedulable' => true },
-            },
+              'spec' => { 'unschedulable' => true }
+            }
           )
           .to_return(
             status: 200,
             headers: { 'Content-Type' => 'application/json' },
-            body: JSON.generate(resource.to_hash),
+            body: JSON.generate(resource.to_hash)
           )
       end
 
@@ -125,11 +129,11 @@ RSpec.describe K8s::ResourceClient do
     end
 
     context "POST /api/v1/nodes/" do
-      let(:resource) { K8s::Resource.new(
-        kind: 'Node',
-        metadata: { name: 'test' },
-        spec: { unschedulable: true },
-      ) }
+      let(:resource) {
+        K8s::Resource.new({ kind: 'Node',
+                            metadata: { name: 'test' },
+                            spec: { unschedulable: true } })
+      }
 
       before do
         stub_request(:post, 'localhost:8080/api/v1/nodes')
@@ -138,13 +142,13 @@ RSpec.describe K8s::ResourceClient do
             body: {
               'kind' => 'Node',
               'metadata' => { 'name' => 'test' },
-              'spec' => { 'unschedulable' => true },
-            },
+              'spec' => { 'unschedulable' => true }
+            }
           )
           .to_return(
             status: 201,
             headers: { 'Content-Type' => 'application/json' },
-            body: JSON.generate(resource.to_hash),
+            body: JSON.generate(resource.to_hash)
           )
       end
 
@@ -162,17 +166,19 @@ RSpec.describe K8s::ResourceClient do
 
   context "for the nodes status API" do
     let(:api_client) { K8s::APIClient.new(transport, 'v1') }
-    let(:api_resource) { K8s::API::MetaV1::APIResource.new(
-      name: "nodes/status",
-      singularName: "",
-      namespaced: false,
-      kind: "Node",
-      verbs: [
-        "get",
-        "patch",
-        "update",
-      ],
-    ) }
+    let(:api_resource) {
+      K8s::API::MetaV1::APIResource.new(
+        name: "nodes/status",
+        singularName: "",
+        namespaced: false,
+        kind: "Node",
+        verbs: %w(
+          get
+          patch
+          update
+        )
+      )
+    }
 
     subject { described_class.new(transport, api_client, api_resource) }
 
@@ -183,11 +189,11 @@ RSpec.describe K8s::ResourceClient do
     end
 
     context "PUT /api/v1/nodes/*/status" do
-      let(:resource) { K8s::Resource.new(
-        kind: 'Node',
-        metadata: { name: 'test', resourceVersion: "1" },
-        status: { foo: 'bar' },
-      ) }
+      let(:resource) {
+        K8s::Resource.new({ kind: 'Node',
+                            metadata: { name: 'test', resourceVersion: "1" },
+                            status: { foo: 'bar' } })
+      }
 
       before do
         stub_request(:put, 'localhost:8080/api/v1/nodes/test/status')
@@ -196,13 +202,13 @@ RSpec.describe K8s::ResourceClient do
             body: {
               'kind' => 'Node',
               'metadata' => { 'name' => 'test', 'resourceVersion' => "1" },
-              'status' => { 'foo' => 'bar' },
-            },
+              'status' => { 'foo' => 'bar' }
+            }
           )
           .to_return(
             status: 200,
             headers: { 'Content-Type' => 'application/json' },
-            body: JSON.generate(resource.to_hash),
+            body: JSON.generate(resource.to_hash)
           )
       end
 
@@ -220,35 +226,37 @@ RSpec.describe K8s::ResourceClient do
 
   context "for the pods API" do
     let(:api_client) { K8s::APIClient.new(transport, 'v1') }
-    let(:api_resource) { K8s::API::MetaV1::APIResource.new(
-      name: "pods",
-      singularName: "",
-      namespaced: true,
-      kind: "Pod",
-      verbs: [
-        "create",
-        "delete",
-        "deletecollection",
-        "get",
-        "list",
-        "patch",
-        "update",
-        "watch",
-      ],
-      shortNames: [
-        "po",
-      ],
-      categories: [
-        "all",
-      ]
-    ) }
+    let(:api_resource) {
+      K8s::API::MetaV1::APIResource.new(
+        name: "pods",
+        singularName: "",
+        namespaced: true,
+        kind: "Pod",
+        verbs: %w(
+          create
+          delete
+          deletecollection
+          get
+          list
+          patch
+          update
+          watch
+        ),
+        shortNames: [
+          "po"
+        ],
+        categories: [
+          "all"
+        ]
+      )
+    }
 
     subject { described_class.new(transport, api_client, api_resource) }
 
-    let(:resource) { K8s::Resource.new(
-      kind: 'Pod',
-      metadata: { name: 'test', namespace: 'default' },
-    ) }
+    let(:resource) {
+      K8s::Resource.new({ kind: 'Pod',
+                          metadata: { name: 'test', namespace: 'default' } })
+    }
     let(:resource_list) { K8s::API::MetaV1::List.new(metadata: {}, items: [resource]) }
 
     context "POST /api/v1/pods/namespaces/default/pods" do
@@ -258,13 +266,13 @@ RSpec.describe K8s::ResourceClient do
             headers: { 'Content-Type' => 'application/json' },
             body: {
               'kind' => 'Pod',
-              'metadata' => { 'name' => 'test', 'namespace' => 'default' },
-            },
+              'metadata' => { 'name' => 'test', 'namespace' => 'default' }
+            }
           )
           .to_return(
             status: 201,
             headers: { 'Content-Type' => 'application/json' },
-            body: JSON.generate(resource.to_hash),
+            body: JSON.generate(resource.to_hash)
           )
       end
 
@@ -286,19 +294,19 @@ RSpec.describe K8s::ResourceClient do
           .with(
             headers: { 'Content-Type' => 'application/strategic-merge-patch+json' },
             body: {
-              'spec' => { 'nodeName': 'foo' },
-            }.to_json, # XXX: webmock doesn't understand +json
+              'spec' => { 'nodeName': 'foo' }
+            }.to_json # XXX: webmock doesn't understand +json
           )
           .to_return(
             status: 201,
             headers: { 'Content-Type' => 'application/json' },
-            body: JSON.generate(resource.to_hash),
+            body: JSON.generate(resource.to_hash)
           )
       end
 
       describe '#merge_patch' do
         it "returns a resource" do
-          obj = subject.merge_patch('test', {'spec' => { 'nodeName' => 'foo'}}, namespace: 'default')
+          obj = subject.merge_patch('test', { 'spec' => { 'nodeName' => 'foo' } }, namespace: 'default')
 
           expect(obj).to match K8s::Resource
           expect(obj.kind).to eq "Pod"


### PR DESCRIPTION
This PR upgrades to the latest dry-types to get rid of the ruby 2.7 keyword argument warning. It also fixes the spec to remove most warning. A few remain that aren't fixed in rspec and recursive open struct