### PR TITLE
WIP: ruby 3.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,3 +25,11 @@ services:
     volumes:
       - .:/app
     entrypoint: bundle exec rspec
+  rspec-3.1:
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ruby:3.1
+    volumes:
+      - .:/app
+    entrypoint: bundle exec rspec

--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = []
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = [">= 2.4", "< 3.1"]
+  spec.required_ruby_version = [">= 2.4", "< 3.2"]
 
   spec.add_runtime_dependency "excon", "~> 0.71"
   spec.add_runtime_dependency "dry-struct", "~> 1.3.0"


### PR DESCRIPTION
`docker-compose up --force-recreate --build rspec-3.1` gives:

```
rspec-3.1_1  |   57) K8s::Transport#self.config for a typical kubeadm admin.conf overriding other options uses the overriden server
rspec-3.1_1  |       Failure/Error: new(YAML.safe_load(File.read(File.expand_path(path)), [Time, DateTime, Date], [], true))
rspec-3.1_1  |
rspec-3.1_1  |       ArgumentError:
rspec-3.1_1  |         wrong number of arguments (given 4, expected 1)
rspec-3.1_1  |       # ./lib/k8s/config.rb:114:in `load_file'
rspec-3.1_1  |       # ./spec/k8s/transport_spec.rb:83:in `block (5 levels) in <top (required)>'
rspec-3.1_1  |       # ./spec/k8s/transport_spec.rb:89:in `block (5 levels) in <top (required)>'
```

etc