### PR TITLE
Make ruby 3.1 compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 #  forked and upgraded to be compatible with ruby 3.1
-gem 'yaml-safe_load_stream3', git: 'https://github.com/sathish-progress/yaml-safe_load_stream3.git', branch: :main # use ssh in case of closed repo
+gem 'yaml-safe_load_stream3', '~> 0.1.2'
 # Specify your gem's dependencies in k8s-ruby.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
+#  forked and upgraded to be compatible with ruby 3.1
+gem 'yaml-safe_load_stream3', git: 'https://github.com/sathish-progress/yaml-safe_load_stream3.git', branch: :main # use ssh in case of closed repo
 # Specify your gem's dependencies in k8s-ruby.gemspec
 gemspec

--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = []
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = [">= 2.4", "< 3.1"]
+  spec.required_ruby_version = spec.required_ruby_version = [">= 2.4", "< 3.2"]
 
   spec.add_runtime_dependency "excon", "~> 0.71"
   spec.add_runtime_dependency "dry-struct", "<= 1.6.0"
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "hashdiff", "~> 1.0.0"
   spec.add_runtime_dependency "jsonpath", "~> 0.9.5"
   spec.add_runtime_dependency "yajl-ruby", "~> 1.4.0"
-  spec.add_runtime_dependency "yaml-safe_load_stream2", "~> 0.1.1"
+  spec.add_runtime_dependency "yaml-safe_load_stream3"
 
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -111,7 +111,10 @@ module K8s
     # @param path [String]
     # @return [K8s::Config]
     def self.load_file(path)
-      new(YAML.safe_load(File.read(File.expand_path(path)), [Time, DateTime, Date], [], true))
+      new(YAML.safe_load(File.read(File.expand_path(path)),
+                         permitted_classes: [Time, DateTime, Date],
+                         permitted_symbols: [],
+                         aliases: true))
     end
 
     # Loads configuration files listed in KUBE_CONFIG environment variable and

--- a/lib/k8s/resource.rb
+++ b/lib/k8s/resource.rb
@@ -23,7 +23,7 @@ module K8s
     # @param filename [String] file path
     # @return [K8s::Resource]
     def self.from_file(filename)
-      new(YAML.safe_load(File.read(filename), [], [], true, filename))
+      new(YAML.safe_load(File.read(filename), permitted_classes: [], permitted_symbols: [], aliases: true, filename: filename))
     end
 
     # @param path [String] file path


### PR DESCRIPTION
k8s-ruby breaks with yaml safe load when run against ruby 3.1.  So, we did the below changes
1. Upgraded yaml-safe_load_stream and made it compatible with ruby 3.1 and pushed it as new gem [inspec/yaml-safe_load_stream3](https://github.com/inspec/yaml-safe_load_stream3) since we don't have access over the original gem 
2. Updated `YAML.safe_load` usages with ruby 3.1 parameterized args