### PR TITLE
Add Ruby 3.1 testing to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: docker-compose build rspec-3.0
       - run: docker-compose run rspec-3.0
+
+  build-3-1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker-compose build rspec-3.1
+      - run: docker-compose run rspec-3.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,3 +20,11 @@ services:
         BASE_IMAGE: ruby:3.0
     volumes:
       - .:/app
+  rspec-3.1:
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ruby:3.1
+    volumes:
+      - .:/app
+    entrypoint: bundle exec rspec


### PR DESCRIPTION
As it says, adds a block for Ruby 3.1 testing to CI using the same pattern for Ruby 3.0.