### PR TITLE
Add support for Ruby 3.2.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: docker-compose build rspec-3.1
       - run: docker-compose run rspec-3.1
+
+  build-3-2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker-compose build rspec-3.2
+      - run: docker-compose run rspec-3.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,4 +27,11 @@ services:
         BASE_IMAGE: ruby:3.1
     volumes:
       - .:/app
+  rspec-3.2:
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ruby:3.2
+    volumes:
+      - .:/app
     entrypoint: bundle exec rspec

--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = []
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = spec.required_ruby_version = [">= 2.4", "< 3.2"]
+  spec.required_ruby_version = spec.required_ruby_version = [">= 2.4", "<= 3.2.2"]
 
   spec.add_runtime_dependency "excon", "~> 0.71"
   spec.add_runtime_dependency "dry-struct", "<= 1.6.0"

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe K8s::Client do
       end
 
       it 'loads a file if found' do
-        allow(File).to receive(:read).with('/etc/kubernetes/kubelet.conf').and_return(kubeconfig)
+        expect(File).to receive(:read).with('/etc/kubernetes/kubelet.conf').and_return(kubeconfig)
         expect(subject.autoconfig).to be_a K8s::Client
       end
     end

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe K8s::Client do
 
     subject { described_class }
     context 'from KUBE_CA/KUBE_SERVER/KUBE_TOKEN variables' do
-
       let(:server) { "localhost" }
       let(:env) { { 'KUBE_TOKEN' => token, 'KUBE_CA' => ca, 'KUBE_SERVER' => server } }
 
@@ -125,18 +124,20 @@ RSpec.describe K8s::Client do
 
     context 'from default file locations' do
       before do
-        stub_const("ENV", {}) # ensure ENV['KUBECONFIG'] is not used
-        expect(File).to receive(:read).and_call_original
-        expect(File).to receive(:exist?).and_call_original
-        expect(File).to receive(:readable?).and_call_original
-        expect(File).to receive(:exist?).with(default_kubeconfig_path).and_return(false)
-        expect(File).to receive(:exist?).with('/etc/kubernetes/admin.conf').and_return(false)
-        expect(File).to receive(:exist?).with('/etc/kubernetes/kubelet.conf').and_return(true)
-        expect(File).to receive(:readable?).with('/etc/kubernetes/kubelet.conf').and_return(true)
+        stub_const("ENV", { 'KUBECONFIG' => nil }) # ensure ENV['KUBECONFIG'] is not used
+
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:readable?).and_call_original
+
+        allow(File).to receive(:exist?).with(default_kubeconfig_path).and_return(false)
+        allow(File).to receive(:exist?).with('/etc/kubernetes/admin.conf').and_return(false)
+        allow(File).to receive(:exist?).with('/etc/kubernetes/kubelet.conf').and_return(true)
+        allow(File).to receive(:readable?).with('/etc/kubernetes/kubelet.conf').and_return(true)
       end
 
       it 'loads a file if found' do
-        expect(File).to receive(:read).with('/etc/kubernetes/kubelet.conf').and_return(kubeconfig)
+        allow(File).to receive(:read).with('/etc/kubernetes/kubelet.conf').and_return(kubeconfig)
         expect(subject.autoconfig).to be_a K8s::Client
       end
     end

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -126,6 +126,9 @@ RSpec.describe K8s::Client do
     context 'from default file locations' do
       before do
         stub_const("ENV", {}) # ensure ENV['KUBECONFIG'] is not used
+        expect(File).to receive(:read).and_call_original
+        expect(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:readable?).and_call_original
         expect(File).to receive(:exist?).with(default_kubeconfig_path).and_return(false)
         expect(File).to receive(:exist?).with('/etc/kubernetes/admin.conf').and_return(false)
         expect(File).to receive(:exist?).with('/etc/kubernetes/kubelet.conf').and_return(true)


### PR DESCRIPTION
Hey there!

This pull request adds support for the latest Ruby version 3.2.2.

## Changelog

- Bumped Ruby requirement on `k8s-ruby.gemspec` to 3.2.2
- Updated `docker-compose.yml` to include new service for 3.2.2
- Updated tests workflow config to include Ruby 3.2.2
- Updated `spec/k8s/client_spec.rb` to make use of `allow` instead of `expect` when setting mocks on `File` (it was causing errors with logger)