### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/lib/k8s/ruby/version.rb
+++ b/lib/k8s/ruby/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Ruby
     # Updated on releases using semver.
-    VERSION = "0.14.0"
+    VERSION = "0.15.0"
   end
 end


### PR DESCRIPTION
Bumps the version from 0.14.0 to 0.15.0

This version bump is on the merged PR https://github.com/k8s-ruby/k8s-ruby/pull/44
this version will start supporting ruby 3.2.2