### PR TITLE
Update dry* run time deps

### DIFF
--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = spec.required_ruby_version = [">= 2.4", "<= 3.2.2"]
 
   spec.add_runtime_dependency "excon", "~> 0.71"
-  spec.add_runtime_dependency "dry-struct", "<= 1.6.0"
-  spec.add_runtime_dependency "dry-types", "<= 1.7.0"
-  spec.add_runtime_dependency "dry-configurable", "~> 0.13.0"
+  spec.add_runtime_dependency "dry-struct"
+  spec.add_runtime_dependency "dry-types"
+  spec.add_runtime_dependency "dry-configurable"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.3"
   spec.add_runtime_dependency "hashdiff", "~> 1.0.0"
   spec.add_runtime_dependency "jsonpath", "~> 0.9.5"

--- a/lib/k8s/ruby/version.rb
+++ b/lib/k8s/ruby/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Ruby
     # Updated on releases using semver.
-    VERSION = "0.15.0"
+    VERSION = "0.15.1"
   end
 end


### PR DESCRIPTION
### Problem: 

AutoCompletion in IRB fails with ruby versions > 3.2.0 because of a known solved bug https://github.com/dry-rb/dry-logic/issues/104

Reproducible steps: 
```
bundle exec irb 
```

```
require 'k8s-ruby'

client = K8s::Client.config(
  K8s::Config.load_file(
    File.expand_path '~/.kube/config'
  )
)

# autocompletion after methods after period and any up arrow shortcuts crashes the irb
client.api('v1').
```

### Solution:

- updating dry-logic gem to 1.5.0 as recommended https://github.com/dry-rb/dry-logic/issues/104#issuecomment-1326778679
- This change fixes that by upgrading the latest version of `dry-types` and also upgrades dependent `dry-struct` and `dry-configurable` gems there by upgrading the dependent `dry-logic` gem as well.





