### PR TITLE
Update jsonpath dependency to 1.1.x

### DIFF
--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-configurable"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.3"
   spec.add_runtime_dependency "hashdiff", "~> 1.0.0"
-  spec.add_runtime_dependency "jsonpath", "~> 1.1.0"
+  spec.add_runtime_dependency "jsonpath", "~> 1.1"
   spec.add_runtime_dependency "yajl-ruby", "~> 1.4.0"
   spec.add_runtime_dependency "yaml-safe_load_stream3"
 


### PR DESCRIPTION
The current version, `0.9.5`, contained a very old dependency `to_regexp ~> 0.2.1`. This had the unintended consequence of breaking some code in our app that made use of ruby's built in `Regexp` libs.
<img width="736" alt="image" src="https://github.com/k8s-ruby/k8s-ruby/assets/8389684/169c857f-fbcb-4a36-b35f-2840ff8a194a">

`jsonpath` dropped `to_regexp` in version `1.0.6`

1.1.5 is the latest and has been tested using this fork in a private app repo