### PR TITLE
Bump version to 0.15.2

### DIFF
--- a/lib/k8s/ruby/version.rb
+++ b/lib/k8s/ruby/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Ruby
     # Updated on releases using semver.
-    VERSION = "0.15.1"
+    VERSION = "0.15.2"
   end
 end


### PR DESCRIPTION
This PR bumps the version of k8s-ruby to 0.15.2