### PR TITLE
feat: exec commands in pod containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .ruby-version
 .tool-versions
 /.byebug_history
+Gemfile.lock
 
 # rspec failure tracking
 .rspec_status

--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -33,6 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "yajl-ruby", "~> 1.4"
   spec.add_runtime_dependency "yaml-safe_load_stream3"
   spec.add_runtime_dependency "base64"
+  spec.add_runtime_dependency "eventmachine", "~> 1.2"
+  spec.add_runtime_dependency "faye-websocket", "~> 0.11"
+  spec.add_runtime_dependency "ruby-termios", "~> 1.1"
 
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "resource_client/exec"
+
 module K8s
   # Per-APIResource type client.
   #
   # Used to get/list/update/patch/delete specific types of resources, optionally in some specific namespace.
+  #
   class ResourceClient
     # Common helpers used in both class/instance methods
     module Utils
@@ -35,6 +38,9 @@ module K8s
 
     include Utils
     extend Utils
+
+    # @!parse include K8s::ResourceClient::Exec
+    include Exec
 
     # Pipeline list requests for multiple resource types.
     #

--- a/lib/k8s/resource_client/exec.rb
+++ b/lib/k8s/resource_client/exec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module K8s
+  class ResourceClient
+    module Exec
+      def self.included(base)
+        base.include(InstanceMethods)
+        base.include(Logging)
+      end
+
+      module InstanceMethods
+        require "eventmachine"
+        require "faye/websocket"
+        require "termios"
+        require "tempfile"
+
+        # Executes arbitrary commands in a container.
+        #
+        # @param name [String] name of the pod
+        # @param namespace [String]
+        # @param container [String] name of the container to execute the command in
+        # @param command [Array<String>|String] command to execute. It accepts a single string or an array of strings if multiple arguments are needed.
+        # @param stdin [Boolean] whether to stream stdin to the container
+        # @param stdout [Boolean] whether to stream stdout from the container
+        # @param tty [Boolean] whether to allocate a tty for the container
+        # @yield [String] Optional block to yield the output of the command
+        # @return [String, nil] output of the command. It returns nil if a block is given or tty is true.
+        #
+        # @example
+        #   client.api('v1').resource('pods', namespace: 'default').exec(
+        #     name: 'test-pod',
+        #     container: 'shell',
+        #     command: '/bin/sh'
+        #   )
+        # @example Open a shell:
+        #   exec(name: 'my-pod', container: 'my-container', command: '/bin/sh')
+        # @example Execute single command:
+        #   exec(name: 'my-pod', container: 'my-container', command: 'date')
+        # @example Pass multiple arguments:
+        #   exec(name: 'my-pod', container: 'my-container', command: ['ls', '-la'])
+        # @example Yield the output of the command:
+        #  exec(
+        #    name: "test-pod",
+        #    container: "shell",
+        #    command: [ "watch", "date" ],
+        #  ) do |out|
+        #    puts "local time #{Time.now}"
+        #    puts "server time #{out}"
+        #  end
+        def exec(name:, namespace: @namespace, command:, container:, stdin: true, stdout: true, tty: true)
+          query = {
+            command: [command].flatten,
+            container: container,
+            stdin: !!stdin,
+            stdout: !!stdout,
+            tty: !!tty
+          }
+
+          exec_path = path(name, namespace: namespace, subresource: "exec")
+          output = StringIO.new
+
+          EM.run do
+            ws = @transport.build_ws_conn(exec_path, query)
+
+            ws.on :message do |event|
+              out = event.data.pack("C*")
+
+              if block_given?
+                yield(out)
+              elsif tty
+                print out
+              else
+                output.write(out)
+              end
+            end
+
+            ws.on :error do |event|
+              logger.error(event.message)
+            end
+
+            term_attributes_original = Termios.tcgetattr($stdin)
+            if tty
+              term_attributes = term_attributes_original.dup
+              term_attributes.lflag &= ~Termios::ECHO
+              term_attributes.lflag &= ~Termios::ICANON
+              Termios.tcsetattr($stdin, Termios::TCSANOW, term_attributes)
+
+              EM.open_keyboard(Module.new do
+                define_method(:receive_data) do |input|
+                  input = [0] + input.unpack("C*")
+                  ws.send(input)
+                end
+              end)
+            end
+
+            ws.on :close do
+              Termios.tcsetattr($stdin, Termios::TCSANOW, term_attributes_original)
+              EM.stop
+            end
+          end
+
+          return if tty
+
+          output.rewind
+          output.read
+        end
+      end
+    end
+  end
+end

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -388,5 +388,50 @@ module K8s
         **options
       )
     end
+
+    # Returns a websocket connection using part of the current transport configuration.
+    # Will use same host and port returned by #server.
+    # @param resource_path [String]
+    # @param query [Hash]
+    # @return [Faye::WebSocket::Client]
+    def build_ws_conn(resource_path, query = {})
+      private_key_file = nil
+      cert_chain_file = nil
+
+      on_open_callbacks = []
+
+      if options[:client_cert] && options[:client_key]
+        private_key_file = options[:client_key]
+        cert_chain_file = options[:client_cert]
+      elsif options[:client_cert_data] && options[:client_key_data]
+        temp_file_path_from_data = lambda do |data|
+          temp_file = Tempfile.new
+          temp_file.write(data)
+          temp_file.close
+          on_open_callbacks << -> { temp_file.unlink }
+          temp_file.path
+        end
+        private_key_file = temp_file_path_from_data.call(options[:client_key_data])
+        cert_chain_file = temp_file_path_from_data.call(options[:client_cert_data])
+      end
+
+      url = server.gsub("http", "ws") +
+            resource_path +
+            Excon::Utils.query_string(query: query)
+
+      ws = Faye::WebSocket::Client.new(
+        url,
+        [],
+        headers: request_options[:headers],
+        tls: {
+          verify_peer: !!options[:ssl_verify_peer],
+          private_key_file: private_key_file,
+          cert_chain_file: cert_chain_file
+        }
+      )
+
+      ws.on(:open) { on_open_callbacks.each(&:call) }
+      ws
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require 'webmock/rspec'
 require 'byebug'
+require 'pty'
 
 require "k8s-ruby"
 
@@ -23,5 +24,13 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:suite) do
+    RSpec::Matchers.define :have_file_content do |expected_content|
+      match do |file_path|
+        File.read(file_path) == expected_content
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR allows to execute arbitrary commands inside a pod container similar to `kubectl exec` command by opening a WS connection to the `/api/v1/namespaces/{namespace}/pods/{name}/exec` API endpoint.

It also allows to open an interactive shell by executing commands like `/bin/sh`

The feature can be tested with something like this:

```ruby
require 'k8s-ruby'

client = K8s::Client.config(K8s::Config.load_file('~/.kube/config'))

test_pod = K8s::Resource.new(
  apiVersion: 'v1',
  kind: 'Pod',
  metadata: {
    name: 'test-pod',
    namespace: 'default'
  },
  spec: {
    containers: [
      {
        name: 'shell',
        image: 'busybox',
        command: [ 'sleep', 'infinity' ]
      }
    ]
  }
)

begin
  client.get_resource(test_pod)
rescue K8s::Error::NotFound
  client.create_resource(test_pod)
end

client.api('v1').resource('pods', namespace: 'default').exec(
  name: "test-pod",
  container: "shell",
  command: "/bin/sh"
)
```

[![asciicast](https://asciinema.org/a/aYjnkZHdNMHyKxmphbf1Eh5tS.svg)](https://asciinema.org/a/aYjnkZHdNMHyKxmphbf1Eh5tS)
