### PR TITLE
Remove upper Ruby constraint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,48 +10,48 @@ jobs:
   build-2-6:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-2.6
       - run: docker compose run rspec-2.6
 
   build-2-7:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-2.7
       - run: docker compose run rspec-2.7
 
   build-3-0:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-3.0
       - run: docker compose run rspec-3.0
 
   build-3-1:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-3.1
       - run: docker compose run rspec-3.1
 
   build-3-2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-3.2
       - run: docker compose run rspec-3.2
 
   build-3-3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-3.3
       - run: docker compose run rspec-3.3
 
   build-3-4:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker compose build rspec-3.4
       - run: docker compose run rspec-3.4

--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = []
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = [">= 2.4", "< 3.5"]
+  spec.required_ruby_version = ">= 2.4"
 
   spec.add_runtime_dependency "excon", "~> 0.71"
   spec.add_runtime_dependency "dry-struct"

--- a/lib/k8s/ruby/version.rb
+++ b/lib/k8s/ruby/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Ruby
     # Updated on releases using semver.
-    VERSION = "0.16.0"
+    VERSION = "0.16.1"
   end
 end


### PR DESCRIPTION
This pull request removes the upper bound on the `required_ruby_version` constraint. It appears to be evident that having an upper bound for a Ruby version is causing more toil than it is worth. Pull requests have to be constantly opened, and a new version needs to be released every single time upstream Ruby releases are published.

It is time to remove this constraint.

See all the issues and pull requests related to this below:

- https://github.com/k8s-ruby/k8s-ruby/issues/49
- https://github.com/k8s-ruby/k8s-ruby/issues/25
- https://github.com/k8s-ruby/k8s-ruby/pull/57
- https://github.com/k8s-ruby/k8s-ruby/pull/50
- https://github.com/k8s-ruby/k8s-ruby/pull/44
- https://github.com/k8s-ruby/k8s-ruby/pull/41
- https://github.com/k8s-ruby/k8s-ruby/pull/28

---

Currently, the `v0.16.0` version of this project doesn't even support Ruby `3.4.1`. After this pull request merges, a new release will need to be published to pick up these changes so that projects running Ruby `3.4.1` can use the newly released `v0.16.1` Gem.

---

> Please note that I also updated the Actions checkout to `v4` in this PR as I noticed it was out-of-date. 🙇 

Thanks!