### PR TITLE
bump minor version of ruby version

### DIFF
--- a/lib/k8s/ruby/version.rb
+++ b/lib/k8s/ruby/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Ruby
     # Updated on releases using semver.
-    VERSION = "0.16.1"
+    VERSION = "0.17.0"
   end
 end


### PR DESCRIPTION
since we are supporting newer versions of ruby this should have been a minor version bump hence bumping the version while we pushed latest k8s-ruby gem as [0.17.0](https://rubygems.org/gems/k8s-ruby/versions/0.17.0) along with this change already.