### PR TITLE
Do Not load EXEC on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,15 @@ client.api('v1').resource('pods', namespace: 'default').watch(labelSelector: {'r
 end
 ```
 
+
+### Exec into running containers
+> **WARNING:** This feature is currently supported only on Linux based platforms. Windows platforms are NOT supported.
+
+#### This opens a new shell in the `test-pod` container
+```ruby
+client.api('v1').resource('pods', namespace: 'default').exec(name: 'test-pod', container: 'shell', command: '/bin/sh')
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at [k8s-ruby/k8s-ruby](https://github.com/k8s-ruby/k8s-ruby).

--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -35,8 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "base64"
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.11"
-  spec.add_runtime_dependency "ruby-termios", "~> 1.1"
-
+  spec.add_runtime_dependency "ruby-termios", "~> 1.1" unless Gem::Platform.local.os =~ /mingw|mswin|windows/
   spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.7"

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "resource_client/exec"
+require_relative "resource_client/exec" unless Gem::Platform.local.os =~ /mingw|mswin|windows/
 
 module K8s
   # Per-APIResource type client.
@@ -39,8 +39,10 @@ module K8s
     include Utils
     extend Utils
 
+    # Don't support Exec for windows since
+    # it depends on ruby-termios which is not supported for Windows platforms
     # @!parse include K8s::ResourceClient::Exec
-    include Exec
+    include Exec if defined?(Exec)
 
     # Pipeline list requests for multiple resource types.
     #

--- a/lib/k8s/ruby/version.rb
+++ b/lib/k8s/ruby/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Ruby
     # Updated on releases using semver.
-    VERSION = "0.17.0"
+    VERSION = "0.17.1"
   end
 end


### PR DESCRIPTION
`exec` resource internally depends on `ruby-termios` which is not supported for windows. 
Hence in order to avoid build failures on windows machines, this is being skipped. 

Fixed Build: 
![image](https://github.com/user-attachments/assets/bcc6a6b6-8b44-476f-9ea5-bef762f83c8b)

