### PR TITLE
Update README.md with additional notes around exec'ing cmd into containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,12 @@ end
 
 
 ### Exec into running containers
-> **WARNING:** This feature is currently supported only on Linux based platforms. Windows platforms are NOT supported.
 
-#### This opens a new shell in the `test-pod` container
+> [!WARNING]  
+> This feature is currently supported only on Linux and Darwin based platforms. Windows platforms are NOT supported. See [#61](https://github.com/k8s-ruby/k8s-ruby/pull/61) for more details.
+
+This opens a new shell in the `test-pod` container:
+
 ```ruby
 client.api('v1').resource('pods', namespace: 'default').exec(name: 'test-pod', container: 'shell', command: '/bin/sh')
 ```


### PR DESCRIPTION
I made this section of the docs a little cleaner by using a [special markdown formatting block for warnings](https://github.com/orgs/community/discussions/16925).

I also made an explicit callout that this should work on both **Linux** and **Darwin** platforms, just not windows.

## Screenshot 📸 

Rendered:

<img width="1169" alt="Screenshot 2025-04-02 at 1 38 10 PM" src="https://github.com/user-attachments/assets/e71190ea-db66-4ddb-8e5e-a1781a9833aa" />

---

Related: https://github.com/k8s-ruby/k8s-ruby/pull/61

cc: @dagi3d @sathish-progress
