### PR TITLE
Update `excon` to 1.3.1

### DIFF
--- a/k8s-ruby.gemspec
+++ b/k8s-ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_runtime_dependency "excon", "~> 0.71"
+  spec.add_runtime_dependency "excon", "~> 1.3.1"
   spec.add_runtime_dependency "dry-struct"
   spec.add_runtime_dependency "dry-types"
   spec.add_runtime_dependency "dry-configurable"

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -183,6 +183,7 @@ module K8s
         persistent: true,
         middlewares: EXCON_MIDDLEWARES,
         headers: REQUEST_HEADERS,
+        include_default_port: !@options[:omit_default_port],
         **@options
       )
     end

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -494,6 +494,37 @@ RSpec.describe K8s::Transport do
       it "returns the test JSON" do
         expect(subject.get('/test')).to eq({'test' => true})
       end
+
+      context 'for a server listening on a default port' do
+        let(:server) { 'http://localhost' }
+
+        before do
+          stub_request(:get, 'localhost/test')
+          .with(headers: { 'Host' => expected_host_header })
+          .to_return(
+            status: 200,
+            body: JSON.dump({'test' => true}),
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        end
+
+        describe 'when omit_default_port is in options' do
+          let(:options) { { omit_default_port: true } }
+          let(:expected_host_header) { 'localhost' }
+
+          it 'does not include the default port in the outbound request' do
+            expect(subject.get('/test')).to eq({'test' => true})
+          end
+        end
+
+        context 'when omit_default_port is not in options' do
+          let(:expected_host_header) { 'localhost:80' }
+
+          it 'includes the default port in the outbound request' do
+            expect(subject.get('/test')).to eq({'test' => true})
+          end
+        end
+      end
     end
 
     context '#get with path prefix' do


### PR DESCRIPTION
Bumps excon to 1.3.1. This includes a breaking change around default ports: https://github.com/excon/excon/pull/856. This pull request preserves existing behavior:
 - defaults to including the default port
 - will omit if `omit_default_port` is set

The additional specs pass both on the current Excon version and on the 1.31 one.
